### PR TITLE
Role based authorization take2

### DIFF
--- a/HouseholdManager/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/HouseholdManager/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -28,6 +28,7 @@ namespace HouseholdManager.Areas.Identity.Pages.Account
         private readonly IUserStore<IdentityUser> _userStore;
         private readonly IUserEmailStore<IdentityUser> _emailStore;
         private readonly ILogger<RegisterModel> _logger;
+        private readonly RoleManager<IdentityRole> _roleManager;
         private readonly IEmailSender _emailSender;
 
         public RegisterModel(
@@ -35,6 +36,7 @@ namespace HouseholdManager.Areas.Identity.Pages.Account
             IUserStore<IdentityUser> userStore,
             SignInManager<IdentityUser> signInManager,
             ILogger<RegisterModel> logger,
+            RoleManager<IdentityRole> roleManager,
             IEmailSender emailSender)
         {
             _userManager = userManager;
@@ -42,6 +44,7 @@ namespace HouseholdManager.Areas.Identity.Pages.Account
             _emailStore = GetEmailStore();
             _signInManager = signInManager;
             _logger = logger;
+            _roleManager = roleManager;
             _emailSender = emailSender;
         }
 
@@ -124,6 +127,13 @@ namespace HouseholdManager.Areas.Identity.Pages.Account
 
                 if (result.Succeeded)
                 {
+                    var userrole = _roleManager.FindByNameAsync("User").Result;
+
+                    if (userrole != null)
+                    {
+                        IdentityResult roleresult = await _userManager.AddToRoleAsync(user, userrole.Name);
+                    }
+
                     _logger.LogInformation("User created a new account with password.");
 
                     var userId = await _userManager.GetUserIdAsync(user);

--- a/HouseholdManager/Controllers/HouseholdController.cs
+++ b/HouseholdManager/Controllers/HouseholdController.cs
@@ -32,6 +32,7 @@ namespace HouseholdManager.Controllers
         }
 
         // GET: Household/AddOrEdit
+        [Authorize(Roles = "Administrator")]
         public async Task<IActionResult> AddOrEdit(int id = 0)
         {
             await PopulateIcons();
@@ -46,6 +47,7 @@ namespace HouseholdManager.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Administrator")]
         public async Task<IActionResult> AddOrEdit([Bind("HouseholdId,HouseholdName,Icon")] Household household)
         {
             if (ModelState.IsValid)
@@ -65,6 +67,7 @@ namespace HouseholdManager.Controllers
         // POST: Household/Delete/5
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Administrator")]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {
             if (_context.Households == null)

--- a/HouseholdManager/Controllers/MemberController.cs
+++ b/HouseholdManager/Controllers/MemberController.cs
@@ -33,6 +33,7 @@ namespace HouseholdManager.Controllers
 
 
         // GET: Member/AddOrEdit
+        [Authorize(Roles = "Administrator")]
         public async Task<IActionResult> AddOrEdit(int id = 0)
         {
             PopulateHouseholds();
@@ -49,6 +50,7 @@ namespace HouseholdManager.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Administrator")]
         public async Task<IActionResult> AddOrEdit([Bind("MemberId,MemberType,Icon,HouseholdId,UserName")] Member member)
         {
             if (ModelState.IsValid)
@@ -70,6 +72,7 @@ namespace HouseholdManager.Controllers
         // POST: Member/Delete/5
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Administrator")]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {
             if (_context.Members == null)

--- a/HouseholdManager/Controllers/MissionController.cs
+++ b/HouseholdManager/Controllers/MissionController.cs
@@ -47,6 +47,7 @@ namespace HouseholdManager.Controllers
         }
 
         // GET: Mission/Create
+        [Authorize(Roles = "Administrator,User")]
         public IActionResult Create()
         {
             PopulateMembers();
@@ -59,6 +60,7 @@ namespace HouseholdManager.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Administrator,User")]
         public async Task<IActionResult> Create([Bind("MissionId,MissionName,RoomId,Point,DueDate,MemberId")] Models.Mission mission)
         {
             if (ModelState.IsValid)
@@ -73,6 +75,7 @@ namespace HouseholdManager.Controllers
         }
 
         // GET: Mission/Edit/5
+        [Authorize(Roles = "Administrator,User")]
         public async Task<IActionResult> Edit(int? id)
         {
             if (id == null || _context.Missions == null)
@@ -95,6 +98,7 @@ namespace HouseholdManager.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Administrator,User")]
         public async Task<IActionResult> Edit(int id, [Bind("MissionId,MissionName,RoomId,Point,DueDate,MemberId")] Models.Mission mission)
         {
             if (id != mission.MissionId)
@@ -128,6 +132,7 @@ namespace HouseholdManager.Controllers
         }
 
         // GET: Mission/Delete/5
+        [Authorize(Roles = "Administrator,User")]
         public async Task<IActionResult> Delete(int? id)
         {
             if (id == null || _context.Missions == null)
@@ -149,6 +154,7 @@ namespace HouseholdManager.Controllers
         // POST: Mission/Delete/5
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Administrator,User")]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {
             if (_context.Missions == null)

--- a/HouseholdManager/Controllers/RoomController.cs
+++ b/HouseholdManager/Controllers/RoomController.cs
@@ -47,6 +47,7 @@ namespace HouseholdManager.Controllers
         }
 
         // GET: Room/Create
+        [Authorize(Roles = "Administrator,User")]
         public async Task<IActionResult> Create()
         {
             await PopulateIcons();
@@ -58,6 +59,7 @@ namespace HouseholdManager.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Administrator,User")]
         public async Task<IActionResult> Create([Bind("RoomId,Name,Icon")] Room room)
         {
             if (ModelState.IsValid)
@@ -71,6 +73,7 @@ namespace HouseholdManager.Controllers
         }
 
         // GET: Room/Edit/5
+        [Authorize(Roles = "Administrator,User")]
         public async Task<IActionResult> Edit(int? id)
         {
 
@@ -94,6 +97,7 @@ namespace HouseholdManager.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Administrator,User")]
         public async Task<IActionResult> Edit(int id, [Bind("RoomId,Name,Icon")] Room room)
         {
             if (id != room.RoomId)
@@ -126,6 +130,7 @@ namespace HouseholdManager.Controllers
         }
 
         // GET: Room/Delete/5
+        [Authorize(Roles = "Administrator,User")]
         public async Task<IActionResult> Delete(int? id)
         {
             if (id == null || _context.Rooms == null)
@@ -146,6 +151,7 @@ namespace HouseholdManager.Controllers
         // POST: Room/Delete/5
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Administrator,User")]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {
             if (_context.Rooms == null)

--- a/HouseholdManager/Program.cs
+++ b/HouseholdManager/Program.cs
@@ -12,6 +12,7 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DevConnection")));
 
 builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = false)
+    .AddRoles<IdentityRole>()
     .AddEntityFrameworkStores<ApplicationDbContext>();
 
 //Register Syncfusion license

--- a/HouseholdManager/Views/Dashboard/Index.cshtml
+++ b/HouseholdManager/Views/Dashboard/Index.cshtml
@@ -32,7 +32,7 @@
 
 <script id="actionColumnTemplate" type="text/x-template">
     <div class="d-flex flex-row justify-content-start">
-        <a class="btn btn-sm no-a-decoration" href="/Mission/AddOrEdit/${MissionId}">
+        <a class="btn btn-sm no-a-decoration" href="/Mission/Edit/${MissionId}">
             <i class="fa-solid fa-pen fa-lg text-secondary"></i>
         </a>
         <form action="/Mission/Delete/${MissionId}" method="post">

--- a/HouseholdManager/Views/Welcome/Index.cshtml
+++ b/HouseholdManager/Views/Welcome/Index.cshtml
@@ -67,10 +67,10 @@
             </p>
         </div>
 
-        <!-- Contributors -->
+        <!-- Members -->
         <div class="w3-container" id="designers" style="margin-top:75px">
 
-            <h1 class="w3-xxxlarge w3-text-red"><b>Contributors.</b></h1>
+            <h1 class="w3-xxxlarge w3-text-red"><b>Members.</b></h1>
             <div class="w3-half">
                 <div class="widget h-100 d-flex justify-content-center align-items-center" style="width:100%" onclick="onClick(this)" alt="Household">
                     <i class="fa-solid fa-users fa-2xl"></i>
@@ -80,7 +80,7 @@
             <p>Remember there is no "I" in teamwork.</p>
             
             <p>
-                Contributors are the people that make up your team.  Add as many as you would like.
+                Members are the people that make up your team.  Add as many as you would like.
             </p>
             <p>
                 <b>


### PR DESCRIPTION
This pull request fixes an issue from the dashboard (link to edit now goes to the right place) and sets up role authorization (users cannot delete members or households...only defaultAdmin can).  New registered users are given "user" authorization, but still need to be added to the household by the defaultAdmin.